### PR TITLE
feat: Redis 사용 refresh & access jwt 발급, 스프링 시큐리티 필터 적용, AuthUser, login & logout 구현

### DIFF
--- a/src/main/java/com/sparta/fitnus/config/JwtAuthenticationToken.java
+++ b/src/main/java/com/sparta/fitnus/config/JwtAuthenticationToken.java
@@ -1,0 +1,25 @@
+package com.sparta.fitnus.config;
+
+import com.sparta.fitnus.user.entity.AuthUser;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+    private final AuthUser authUser;
+
+    public JwtAuthenticationToken(AuthUser authUser) {
+        super(authUser.getAuthorities());
+        this.authUser = authUser;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return authUser;
+    }
+}
+

--- a/src/main/java/com/sparta/fitnus/config/JwtSecurityFilter.java
+++ b/src/main/java/com/sparta/fitnus/config/JwtSecurityFilter.java
@@ -1,0 +1,116 @@
+package com.sparta.fitnus.config;
+
+import com.sparta.fitnus.user.entity.AuthUser;
+import com.sparta.fitnus.user.enums.UserRole;
+import com.sparta.fitnus.user.service.RedisUserService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtSecurityFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final RedisUserService redisUserService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 쿠키에서 Access Token 추출
+        String accessToken = jwtUtil.resolveTokenFromCookie(request);
+
+        if (accessToken != null) {
+            try {
+                // Access Token 유효성 검사
+                if (jwtUtil.validateToken(accessToken)) {
+                    log.info("Access token is valid, continuing request");
+
+                    // Access Token에서 사용자 정보 및 권한 추출
+                    Claims claims = jwtUtil.extractClaims(accessToken);
+                    Long userId = Long.parseLong(claims.getSubject());
+                    String userRole = claims.get("UserRole", String.class);
+                    String email = claims.get("email", String.class);
+
+                    // AuthUser 객체 생성
+                    AuthUser authUser = new AuthUser(userId, UserRole.valueOf(userRole), email);
+
+                    // SecurityContext에 AuthUser 설정
+                    Authentication authentication = new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                    // 필터 체인 계속 진행
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+            } catch (ExpiredJwtException e) {
+                log.info("Access token expired, attempting to refresh using Refresh Token");
+
+                // 만료된 Access Token에서 클레임 추출
+                Claims claims = e.getClaims();
+                Long userId = Long.parseLong(claims.getSubject());
+                String email = claims.get("email", String.class);
+                String userRole = claims.get("UserRole", String.class);
+
+                // Redis에서 Refresh Token 조회
+                String refreshToken = redisUserService.getRefreshToken(userId.toString());
+
+                // Refresh Token 유효성 검사
+                if (refreshToken != null && jwtUtil.validateToken(refreshToken)) {
+                    log.info("Refresh token is valid. Issuing new access token.");
+
+                    // 새로운 Access Token 생성
+                    String newAccessToken = jwtUtil.createAccessToken(userId, email, userRole);
+
+                    // Redis에 새로운 Access Token 저장 (필요시)
+                    redisUserService.updateAccessToken(userId.toString(), newAccessToken);
+
+                    // 새로운 Access Token을 쿠키에 저장
+                    jwtUtil.setTokenCookie(response, newAccessToken);
+
+                    // AuthUser 객체 생성 및 SecurityContext에 설정
+                    AuthUser authUser = new AuthUser(userId, UserRole.valueOf(userRole), email);
+                    Authentication authentication = new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                    log.info("New access token issued and added to cookies. Proceeding with the request.");
+
+                    // 필터 체인 계속 진행
+                    filterChain.doFilter(request, response);
+                    return;
+                } else {
+                    log.warn("Refresh token expired or not found. Forcing re-login.");
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token expired. Please log in again.");
+                    return;
+                }
+            }
+        } else {
+            log.warn("No access token found in request. Possibly trying to access a public endpoint.");
+        }
+
+        // Access Token이 없는 경우, 필터 체인을 계속 진행
+        filterChain.doFilter(request, response);
+    }
+}
+
+
+
+
+
+
+
+

--- a/src/main/java/com/sparta/fitnus/config/JwtUtil.java
+++ b/src/main/java/com/sparta/fitnus/config/JwtUtil.java
@@ -1,0 +1,132 @@
+package com.sparta.fitnus.config;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+    private final long ACCESS_TOKEN_EXPIRATION = 60 * 60 * 1000L; // 60분 (테스트용)
+    private final long REFRESH_TOKEN_EXPIRATION = 1 * 24 * 60 * 60 * 1000L; // 1일
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @Value("${jwt.secret_key}")
+    private String secretKey;
+    private Key key;
+
+    // Secret Key를 기반으로 HMAC SHA256 알고리즘을 위한 초기화
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    // Access Token 생성 (Bearer prefix 없이 쿠키에 저장)
+    public String createAccessToken(Long userId, String email, String role) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(Long.toString(userId))  // 사용자 ID 설정
+                .claim("UserRole", role)  // 사용자 권한 추가
+                .claim("email", email)  // 이메일 추가
+                .setIssuedAt(now)  // 발급 시간
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION))  // 만료 시간 설정
+                .signWith(key, signatureAlgorithm)  // 서명 알고리즘과 키로 서명
+                .compact();
+    }
+
+    // Refresh Token 생성
+    public String createRefreshToken(Long userId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(Long.toString(userId))  // 사용자 ID 설정
+                .setIssuedAt(now)  // 발급 시간
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION))  // 만료 시간 설정
+                .signWith(key, signatureAlgorithm)  // 서명 알고리즘과 키로 서명
+                .compact();
+    }
+
+    // Token 유효성 검사 (Access Token과 Refresh Token 둘 다 검증 가능)
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;  // 토큰이 유효하면 true 반환
+        } catch (ExpiredJwtException e) {
+            throw e;  // 만료된 경우 예외를 던짐 (Refresh 용도로 따로 처리)
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            log.error("Invalid JWT signature");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty.");
+        }
+        return false;
+    }
+
+    // JWT에서 클레임(Claims) 추출 (추가된 메서드)
+    public Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)  // 서명에 사용된 키로 파싱
+                .build()
+                .parseClaimsJws(token)  // 토큰에서 클레임 추출
+                .getBody();  // 클레임 반환
+    }
+
+    // Access Token을 쿠키에 저장 (Bearer prefix 없이)
+    public void setTokenCookie(HttpServletResponse response, String token) {
+        Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token);
+        cookie.setHttpOnly(true);  // XSS 공격 방지를 위해 HttpOnly 설정
+        cookie.setMaxAge(7 * 24 * 60 * 60);  // 쿠키의 만료 시간 7일로 설정 (Access Token 만료 시간과는 별개)
+        cookie.setPath("/");  // 쿠키의 경로를 루트로 설정
+        response.addCookie(cookie);
+    }
+
+    // 쿠키에서 Access Token 추출
+    public String resolveTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(AUTHORIZATION_HEADER)) {
+                    return cookie.getValue();  // 쿠키에서 JWT 토큰 값 반환
+                }
+            }
+        }
+        return null;  // 쿠키가 없으면 null 반환
+    }
+
+    // Bearer prefix를 제거하는 메서드
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);  // "Bearer " 제거 후 반환
+        }
+        throw new IllegalArgumentException("Token does not start with Bearer");
+    }
+
+    // 쿠키에서 Access Token 삭제
+    public void clearTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie(AUTHORIZATION_HEADER, null);
+        cookie.setMaxAge(0);  // 쿠키 즉시 만료
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");  // 쿠키 경로 설정
+        response.addCookie(cookie);
+    }
+
+}
+
+
+
+
+

--- a/src/main/java/com/sparta/fitnus/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/fitnus/config/SecurityConfig.java
@@ -1,4 +1,51 @@
 package com.sparta.fitnus.config;
 
+import com.sparta.fitnus.user.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
+    private final JwtSecurityFilter jwtSecurityFilter;
+    private final Environment env;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // SessionManagementFilter, SecurityContextPersistenceFilter
+                )
+                .addFilterBefore(jwtSecurityFilter, SecurityContextHolderAwareRequestFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable) // UsernamePasswordAuthenticationFilter, DefaultLoginPageGeneratingFilter 비활성화
+                .anonymous(AbstractHttpConfigurer::disable) // AnonymousAuthenticationFilter 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable) // BasicAuthenticationFilter 비활성화
+                .logout(AbstractHttpConfigurer::disable) // LogoutFilter 비활성화
+
+                .authorizeHttpRequests(auth -> {
+                    auth.requestMatchers("/api/v1/auth/login").permitAll()
+                            .requestMatchers("/test").hasAuthority(UserRole.Authority.ADMIN)
+                            .anyRequest().authenticated();
+                })
+                .build();
+    }
 }

--- a/src/main/java/com/sparta/fitnus/user/controller/UserController.java
+++ b/src/main/java/com/sparta/fitnus/user/controller/UserController.java
@@ -3,12 +3,16 @@ package com.sparta.fitnus.user.controller;
 import com.sparta.fitnus.common.apipayload.ApiResponse;
 import com.sparta.fitnus.user.dto.request.UserRequest;
 import com.sparta.fitnus.user.dto.response.UserResponse;
+import com.sparta.fitnus.user.entity.AuthUser;
 import com.sparta.fitnus.user.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collection;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +24,30 @@ public class UserController {
     @PostMapping("/v1/auth/signup")
     public ApiResponse<UserResponse> signup(@RequestBody UserRequest userRequest) {
         return ApiResponse.createSuccess(userService.signup(userRequest));
+    }
+
+    @PostMapping("/v1/auth/login")
+    public ApiResponse<String> login(@RequestBody UserRequest userRequest, HttpServletResponse response) {
+        return ApiResponse.createSuccess(userService.login(userRequest, response));
+    }
+
+    @PostMapping("/v1/auth/logout")
+    public ApiResponse<String> logout(@AuthenticationPrincipal AuthUser authUser, HttpServletResponse response) {
+        return ApiResponse.createSuccess(userService.logout(authUser, response));
+    }
+
+    // 현재 인증된 사용자 정보에 접근하는 예시
+    @GetMapping("/test")
+    public ApiResponse<?> getProfile(@AuthenticationPrincipal AuthUser authUser) {
+        // 인증된 사용자의 정보에 접근 가능
+        Long userId = authUser.getId();
+        String email = authUser.getEmail();
+        Collection<? extends GrantedAuthority> authorities = authUser.getAuthorities();
+
+        return ApiResponse.createSuccess(Map.of(
+                "userId", userId,
+                "email", email,
+                "authorities", authorities
+        ));
     }
 }

--- a/src/main/java/com/sparta/fitnus/user/dto/request/UserRequest.java
+++ b/src/main/java/com/sparta/fitnus/user/dto/request/UserRequest.java
@@ -18,4 +18,8 @@ public class UserRequest {
     private boolean admin = false;
 
     private String adminToken = "";
+
+    public void setEncodedPassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/sparta/fitnus/user/entity/AuthUser.java
+++ b/src/main/java/com/sparta/fitnus/user/entity/AuthUser.java
@@ -1,0 +1,22 @@
+package com.sparta.fitnus.user.entity;
+
+import com.sparta.fitnus.user.enums.UserRole;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class AuthUser {
+    private final Long id;
+    private final Collection<? extends GrantedAuthority> authorities;
+    private final String email;
+
+    public AuthUser(Long id, UserRole role, String email) {
+        this.id = id;
+        this.authorities = List.of(new SimpleGrantedAuthority((role.name())));
+        this.email = email;
+    }
+}

--- a/src/main/java/com/sparta/fitnus/user/service/RedisUserService.java
+++ b/src/main/java/com/sparta/fitnus/user/service/RedisUserService.java
@@ -1,0 +1,39 @@
+package com.sparta.fitnus.user.service;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class RedisUserService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisUserService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // Access Token과 Refresh Token 저장
+    public void saveTokens(String userId, String accessToken, String refreshToken) {
+        redisTemplate.opsForValue().set("ACCESS_TOKEN_" + userId, accessToken, 30, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set("REFRESH_TOKEN_" + userId, refreshToken, 1, TimeUnit.DAYS);
+    }
+
+    // Refresh Token 조회
+    public String getRefreshToken(String userId) {
+        return redisTemplate.opsForValue().get("REFRESH_TOKEN_" + userId);
+    }
+
+    // Access Token 갱신
+    public void updateAccessToken(String userId, String newAccessToken) {
+        redisTemplate.opsForValue().set("ACCESS_TOKEN_" + userId, newAccessToken, 30, TimeUnit.MINUTES);
+    }
+
+    // 로그아웃 시 토큰 삭제
+    public void deleteTokens(String userId) {
+        redisTemplate.delete("ACCESS_TOKEN_" + userId);
+        redisTemplate.delete("REFRESH_TOKEN_" + userId);
+    }
+
+}

--- a/src/main/java/com/sparta/fitnus/user/service/UserService.java
+++ b/src/main/java/com/sparta/fitnus/user/service/UserService.java
@@ -3,14 +3,20 @@ package com.sparta.fitnus.user.service;
 import com.sparta.fitnus.common.exception.DuplicateEmailException;
 import com.sparta.fitnus.common.exception.NotFoundException;
 import com.sparta.fitnus.common.exception.WrongAdminTokenException;
+import com.sparta.fitnus.common.exception.WrongPasswordException;
+import com.sparta.fitnus.config.JwtUtil;
 import com.sparta.fitnus.user.dto.request.UserRequest;
 import com.sparta.fitnus.user.dto.response.UserResponse;
+import com.sparta.fitnus.user.entity.AuthUser;
 import com.sparta.fitnus.user.entity.User;
 import com.sparta.fitnus.user.enums.UserRole;
 import com.sparta.fitnus.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,18 +28,63 @@ public class UserService {
     private final UserRepository userRepository;
     @Value("${admin.token}")
     private String ADMIN_TOKEN;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+    private final RedisUserService redisUserService;
 
     @Transactional
     public UserResponse signup(@Valid UserRequest userRequest) {
         //이메일 중복검증
         validateDuplicateEmail(userRequest.getEmail());
-
+        String encodedPassword = passwordEncoder.encode(userRequest.getPassword());
+        userRequest.setEncodedPassword(encodedPassword);
         UserRole role = UserRole.USER;
         //adminToken 검증
         role = validateAdminToken(userRequest, role);
         User user = User.of(userRequest, role);
         User savedUser = userRepository.save(user);
         return new UserResponse(savedUser);
+    }
+
+    public String login(UserRequest userRequest, HttpServletResponse response) {
+        User user = getUserFromEmail(userRequest.getEmail());
+        validatePassword(userRequest.getPassword(), user.getPassword());
+
+        // ACCESS_TOKEN와 REFRESH_TOKEN 생성
+        Long userId = user.getId();  // 사용자 id
+        String role = user.getUserRole().name();  // 역할
+
+
+        // Access Token과 Refresh Token 발급
+        String accessToken = jwtUtil.createAccessToken(userId, user.getEmail(), role);
+        String refreshToken = jwtUtil.createRefreshToken(userId);
+
+        // Redis에 토큰 저장 (Access Token과 Refresh Token)
+        redisUserService.saveTokens(String.valueOf(userId), accessToken, refreshToken);
+
+        // Access Token을 쿠키에 저장
+        jwtUtil.setTokenCookie(response, accessToken);
+
+        // Refresh Token을 응답 헤더에 담아 보내는 방법 (예시)
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Set-Cookie", "refreshToken=" + refreshToken + "; HttpOnly; Path=/; Max-Age=604800");
+
+        return "로그인 완료";
+    }
+
+    public String logout(AuthUser authUser, HttpServletResponse response) {
+        // Redis에서 Refresh Token 삭제
+        redisUserService.deleteTokens(authUser.getId().toString());
+
+        // 쿠키에서 Access Token 삭제º
+        jwtUtil.clearTokenCookie(response);
+        return "로그아웃 완료";
+    }
+
+    private void validatePassword(String rawPassword, String encodedPassword) {
+        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+            throw new WrongPasswordException();
+        }
     }
 
     public User getUser(Long userId) {


### PR DESCRIPTION
로그인시 refresh & access토큰 redis & 쿠키 에저장
access토큰 만료시 filter에서 refresh토큰 조회후 재발급
토큰 기반으로 userid, role, email authuser에 저장
로그아웃시 쿠키 및 redis 에서 삭제